### PR TITLE
upgrade stack lts to LTS-18.27

### DIFF
--- a/servant-prometheus.cabal
+++ b/servant-prometheus.cabal
@@ -29,7 +29,7 @@ library
                      , Servant.Prometheus.Internal.StatusCodes
   build-depends:       base >= 4.7 && < 4.15
                      , prometheus-client >= 1.0
-                     , servant > 0.10 && < 0.17
+                     , servant > 0.10 && < 0.19
                      , servant-auth
                      , servant-server
                      , http-types

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.16
+resolver: lts-18.27
 
 packages:
 - '.'

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 524804
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/16.yaml
-    sha256: 4d1519a4372d051d47a5eae2241cf3fb54e113d7475f89707ddb6ec06add2888
-  original: lts-14.16
+    size: 590102
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/27.yaml
+    sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe
+  original: lts-18.27


### PR DESCRIPTION
Bump to new stack LTS version and remove servant package constraints
what allows to use latest servant versions.